### PR TITLE
Change math -> random module for randomize

### DIFF
--- a/websocket/shared.nim
+++ b/websocket/shared.nim
@@ -1,5 +1,5 @@
 import asyncdispatch, asyncnet, streams, nativesockets, strutils, tables,
-  times, oids, math
+  times, oids, random
 
 type
   ProtocolError* = object of Exception


### PR DESCRIPTION
This was a breaking change in 0.14 (?)
Changing from `import math` to `import random` so can use randomize method