### PR TITLE
fix Error: type mismatch: got (byte) but expected 'int'

### DIFF
--- a/websocket/shared.nim
+++ b/websocket/shared.nim
@@ -127,7 +127,7 @@ proc recvFrame*(ws: AsyncSocket): Future[Frame] {.async.} =
     finalLen = cast[ptr int32](lenstr[4].addr)[].htonl
 
   else:
-    finalLen = hdrLen
+    finalLen = hdrLen.int32
 
   f.masked = (b1 and 0x80) == 0x80
   var maskingKey = ""


### PR DESCRIPTION
fix websocket/shared.nim(130, 14) Error: type mismatch: got (byte) but expected 'int'