### PR TITLE
Put back trailing "\r\n" in client, small documentation fix.

### DIFF
--- a/websocket/client.nim
+++ b/websocket/client.nim
@@ -75,6 +75,7 @@ proc newAsyncWebsocket*(host: string, port: Port, path: string, ssl = false,
     msg.add("Sec-WebSocket-Protocol: " & protocols.join(", ") & "\c\L")
   for h in additionalHeaders:
     msg.add(h[0] & ": " & h[1] & "\c\L")
+  msg.add("\c\L")
 
   await s.send(msg)
 

--- a/websocket/server.nim
+++ b/websocket/server.nim
@@ -31,6 +31,8 @@
 ##
 ##       req.client.close()
 ##       echo ".. socket went away."
+##
+##   waitfor server.serve(Port(8080), cb)
 
 import asyncnet, asyncdispatch, asynchttpserver, strtabs, base64, securehash,
   strutils, sequtils


### PR DESCRIPTION
I haven't done much testing on this yet - it gets further than before but maybe it breaks for other reasons.