### PR TITLE
fixes #27

### DIFF
--- a/websocket/client.nim
+++ b/websocket/client.nim
@@ -50,9 +50,12 @@ proc newAsyncWebsocket*(host: string, port: Port, path: string, ssl = false,
   ## one the server offers (if any).
   ## The negotiated protocol is in `AsyncWebSocket.protocol`.
 
-  let key = encode($(getTime().int))
+  let
+    keyDec = align($(getTime().int), 16, '#')
+    key = encode(keyDec)
+    s = newAsyncSocket()
+  assert keyDec.len == 16
 
-  let s = newAsyncSocket()
   if ssl:
     when not defined(ssl):
       raise newException(Exception, "Cannot connect over SSL without -d:ssl")


### PR DESCRIPTION
fixes #27

> The request MUST include a header field with the name
> |Sec-WebSocket-Key|.  The value of this header field MUST be a
> nonce consisting of a randomly selected 16-byte value that has
> been base64-encoded (see Section 4 of [RFC4648]).  The nonce
> MUST be selected randomly for each connection.
> 
> From https://tools.ietf.org/html/rfc6455 