### PR TITLE
fix compilation Error: type mismatch: got <Time> but expected 'int64'

### DIFF
--- a/websocket.nimble
+++ b/websocket.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.3"
+version       = "0.2.4"
 author        = "niv"
 description   = "websockets for nim"
 license       = "MIT"

--- a/websocket/client.nim
+++ b/websocket/client.nim
@@ -51,7 +51,7 @@ proc newAsyncWebsocket*(host: string, port: Port, path: string, ssl = false,
   ## The negotiated protocol is in `AsyncWebSocket.protocol`.
 
   let
-    keyDec = align($(getTime().int64), 16, '#')
+    keyDec = align($(getTime().toUnix.int64), 16, '#')
     key = encode(keyDec)
     s = newAsyncSocket()
 


### PR DESCRIPTION
`client.nim(54, 31) Error: type mismatch: got <Time> but expected 'int64'`